### PR TITLE
Added exception handling and error printing for MTGA parsing errors

### DIFF
--- a/mtga2csv.py
+++ b/mtga2csv.py
@@ -105,8 +105,11 @@ for cardEntry in contents:
     tokens = {'cardQuantity': '', 'cardName': '', 'cardSetId': '', 'cardSetNumber': ''}
     delimeters = [" ", "\(", "\)"]
     pair = ["", cardEntry]
-    for (delimeter, key) in zip(delimeters, tokens):
-        pair = re.split(delimeter,pair[1], maxsplit=1)
-        tokens[key] = pair[0].strip()
-    tokens['cardSetNumber'] = pair[1].strip()
-    csvLineWrite(tokens, csvOutputFile)
+    try:
+        for (delimeter, key) in zip(delimeters, tokens):
+            pair = re.split(delimeter,pair[1], maxsplit=1)
+            tokens[key] = pair[0].strip()
+        tokens['cardSetNumber'] = pair[1].strip()
+        csvLineWrite(tokens, csvOutputFile)
+    except IndexError:
+        print("Unable to parse entry: " + cardEntry)


### PR DESCRIPTION
Accidentally found how to crash the MTGA script by simply giving it the wrong file format. Thought it would be best to handle the exception rather than leaving it as-is.